### PR TITLE
Update dependencies to fix Snyk vulnerabilites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.13.RELEASE</version>
+    <version>2.3.0.RELEASE</version>
 </parent>
 
 <properties>
@@ -30,10 +30,20 @@
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-data-jpa</artifactId>
+        <version>2.2.12.RELEASE</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>4.3.29.RELEASE</version>
     </dependency>
     <dependency>
         <groupId>org.springframework</groupId>
@@ -80,6 +90,11 @@
         <version>5.1.0.Final</version>
     </dependency>
     <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-core</artifactId>
+        <version>5.4.24.Final</version>
+    </dependency>
+    <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.4</version>
@@ -123,7 +138,7 @@
     <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.52</version>
+        <version>1.61</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/inin/keymanagement/services/DecryptionService.java
+++ b/src/main/java/com/inin/keymanagement/services/DecryptionService.java
@@ -42,7 +42,7 @@ public class DecryptionService {
      * @return Decrypt response with the decrypted kek
      */
     public DecryptResponse decrypt(String base64Text, String keypairId, String decryptType){
-        Keypair keypair = keypairRepository.findOne(keypairId);
+        Keypair keypair = keypairRepository.findById(keypairId).orElse(null);
         if (keypair == null){
             throw new BadRequestException("No key pair found with the id provided");
         }

--- a/src/main/java/com/inin/keymanagement/services/HawkAuthentication.java
+++ b/src/main/java/com/inin/keymanagement/services/HawkAuthentication.java
@@ -5,7 +5,6 @@ import com.inin.keymanagement.exceptions.BadRequestException;
 import com.inin.keymanagement.models.dao.HawkModel;
 import com.inin.keymanagement.models.dto.auth.HawkRequest;
 import com.inin.keymanagement.models.repositories.HawkDaoRepository;
-import com.inin.keymanagement.utils.CryptographyHelper;
 import net.jalg.hawkj.Algorithm;
 import net.jalg.hawkj.AuthorizationHeader;
 import net.jalg.hawkj.HawkContext;
@@ -17,9 +16,7 @@ import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 import java.math.BigInteger;
-import java.net.URI;
 import java.security.SecureRandom;
-import java.util.Optional;
 
 /**
  * This class handles the hawk authentication. https://github.com/hueniverse/hawk
@@ -37,7 +34,7 @@ public class HawkAuthentication {
      * @return the hawkmodel with important service related information
      */
     public HawkModel registerService(HawkRequest hr) {
-        if (hr.getId() == null || hr.getId().length() < 6 || repository.findOne(hr.getId()) != null) {
+        if (hr.getId() == null || hr.getId().length() < 6 || repository.findById(hr.getId()).isPresent()) {
             throw new BadRequestException("authentication needs a unique id and must be over 5 characters");
         }
         HawkModel hm = generateHawkModel(hr.getId());
@@ -50,7 +47,7 @@ public class HawkAuthentication {
      * @return hawk model
      */
     public HawkModel getHawkModel(String id) {
-        return repository.findOne(id);
+        return repository.findById(id).orElse(null);
     }
 
     /**

--- a/src/main/java/com/inin/keymanagement/services/KeyManagementService.java
+++ b/src/main/java/com/inin/keymanagement/services/KeyManagementService.java
@@ -7,15 +7,9 @@ import com.inin.keymanagement.models.dto.PrivatePublicTuple;
 import com.inin.keymanagement.models.repositories.KeypairRepository;
 import com.inin.keymanagement.utils.CryptographyHelper;
 import org.apache.commons.codec.binary.Base64;
-import org.bouncycastle.asn1.ASN1Primitive;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
-import org.bouncycastle.asn1.pkcs.RSAPrivateKey;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.security.*;
 import java.util.Date;
 import java.util.List;
 
@@ -33,7 +27,7 @@ public class KeyManagementService {
     }
 
     public Keypair getKeyPair(String id) {
-        return keypairRepository.findOne(id);
+        return keypairRepository.findById(id).orElse(null);
     }
 
     public List<Keypair> getKeypairs(){

--- a/src/main/java/com/inin/keymanagement/services/RequestLoggingService.java
+++ b/src/main/java/com/inin/keymanagement/services/RequestLoggingService.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 @Service
 public class RequestLoggingService {
-    private static Sort timestampSort = new Sort(Sort.Direction.DESC, "timestamp");
+    private static Sort timestampSort = Sort.by(Sort.Direction.DESC, "timestamp");
 
     @Autowired
     RequestLogRepository requestLogRepository;
@@ -28,7 +28,7 @@ public class RequestLoggingService {
 
     public synchronized List<RequestLog> getRequestLogEntries(int maxEntries, LocalDateTime earliestTime, LocalDateTime latestTime) {
         return requestLogRepository.findByTimestampBetween(earliestTime, latestTime,
-                new PageRequest(0, maxEntries, timestampSort));
+                PageRequest.of(0, maxEntries, timestampSort));
     }
 
     public synchronized void clearRequestLogEntries() {

--- a/src/test/java/com/inin/keymanagement/services/DecryptionServiceTest.java
+++ b/src/test/java/com/inin/keymanagement/services/DecryptionServiceTest.java
@@ -4,7 +4,6 @@ import com.inin.keymanagement.exceptions.BadRequestException;
 import com.inin.keymanagement.models.dao.Keypair;
 import com.inin.keymanagement.models.dto.DecryptResponse;
 import com.inin.keymanagement.models.repositories.KeypairRepository;
-import com.inin.keymanagement.utils.CryptographyHelper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.Mockito.*;
@@ -30,7 +30,7 @@ public class DecryptionServiceTest {
     @Test
     public void testDecryption(){
         Keypair keypair = createKeypair();
-        when(keypairRepository.findOne(anyString())).thenReturn(keypair);
+        when(keypairRepository.findById(anyString())).thenReturn(Optional.of(keypair));
 
         DecryptResponse decryptResponse = decryptionService.decrypt(getEncryptedKey(), keypair.getId(), null);
         Assert.assertEquals(decryptResponse.getBody(), "7+YOUOgTgqOfhKRq0//eS94VrhyCwiYbQQcgfrOaG5g=");
@@ -39,7 +39,7 @@ public class DecryptionServiceTest {
     @Test
     public void testDecryptionOfPKCS1() {
         Keypair keypair = createCMSKeypair();
-        when(keypairRepository.findOne(anyString())).thenReturn(keypair);
+        when(keypairRepository.findById(anyString())).thenReturn(Optional.of(keypair));
 
         DecryptResponse decryptResponse = decryptionService.decrypt(getPKCS1EncryptedDek(), keypair.getId(), "pkcs1");
         Assert.assertEquals("PKIKLwo2+u9VH4tDHRizx8Lk9eyz2H/yUA6P6uqsKy8=", decryptResponse.getBody());
@@ -47,7 +47,7 @@ public class DecryptionServiceTest {
 
     @Test(expected = BadRequestException.class)
     public void testNullKeyPairDecryption(){
-        when(keypairRepository.findOne(anyString())).thenReturn(null);
+        when(keypairRepository.findById(anyString())).thenReturn(Optional.empty());
         decryptionService.decrypt("string", "keypairId", null);
     }
 

--- a/src/test/java/com/inin/keymanagement/services/HawkAuthenticationTest.java
+++ b/src/test/java/com/inin/keymanagement/services/HawkAuthenticationTest.java
@@ -11,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -28,7 +30,7 @@ public class HawkAuthenticationTest {
         hModel.setAlgorithm("sha256");
         hModel.setId("DerekM");
         hModel.setAuthKey("SomeKey");
-        when(repository.findOne(anyString())).thenReturn(null);
+        when(repository.findById(anyString())).thenReturn(Optional.empty());
         when(repository.save(any(HawkModel.class))).thenReturn(new HawkModel());
         HawkRequest hr = new HawkRequest();
         hr.setId("DerekM");
@@ -40,7 +42,7 @@ public class HawkAuthenticationTest {
 
     @Test(expected = BadRequestException.class)
     public void hawkNoDuplicateIds(){
-        when(repository.findOne(anyString())).thenReturn(new HawkModel());
+        when(repository.findById(anyString())).thenReturn(Optional.of(new HawkModel()));
         HawkRequest hr = new HawkRequest();
         hr.setId("Derek");
         hawkAuthentication.registerService(hr);


### PR DESCRIPTION
Updated packages to fix sevUeral high severity vulnerabilities reported by Snyk.

Between spring-boot-starter-parent@1.5.13 and spring-boot-starter-parent@2.3.0:
 - the findOne method of CRUDRepository was replaced with findById, which returns an Optional. I rewrote the calls to this method to address that
 - Sort and PageRequest no longer have public access. Instead, we now use Sort.by(…) and PageRequest.of(…)