### PR TITLE
QM-12892 Upgrade dependencies to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
     <com.fasterxml.jackson.version>2.11.0</com.fasterxml.jackson.version>
     <java.version>1.8</java.version>
     <scala.version>2.10.4</scala.version>
+    <log4j.version>2.16.0</log4j.version>
+    <spring-framework.version>5.3.20</spring-framework.version>
+
 </properties>
 
 <dependencies>
@@ -44,6 +47,11 @@
     <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>${log4j.version}</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Upgrades spring framework from 5.2.6 to the latest 5.3.20 to pull vulnerability fix, as well as upgrading log4j-to-slf4j to 2.16.0 for a vulnerability fix