### PR TITLE
QM-15691 Updated spring framework to address Snyk vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <java.version>1.8</java.version>
     <scala.version>2.10.4</scala.version>
     <log4j.version>2.16.0</log4j.version>
-    <spring-framework.version>5.3.20</spring-framework.version>
+    <spring-framework.version>5.3.26</spring-framework.version>
 
 </properties>
 


### PR DESCRIPTION
this upgrade is to avoid [CVE-2023-20860](https://www.cve.org/CVERecord?id=CVE-2023-20860) which was addressed in Spring Framework 5.3.26