### PR TITLE
RECINF-323: Removed support for h2 database due to snyk vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,11 +135,6 @@
         <version>24.1.1-jre</version>
     </dependency>
     <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>2.1.210</version>
-    </dependency>
-    <dependency>
         <groupId>org.mindrot</groupId>
         <artifactId>jbcrypt</artifactId>
         <version>0.4</version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,7 @@
-#For H2, not for production use
-spring.datasource.url=jdbc:h2:file:~/local_key
-spring.datasource.username=sa
-spring.datasource.password=password
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.initialize=true
-
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.show-sql=false
-spring.jpa.hibernate.ddl-auto=update
+#Support for H2 database has been removed due to snyk vulnerability -  https://security.snyk.io/vuln/SNYK-JAVA-COMH2DATABASE-31685
+#spring.datasource.initialize=true
+#spring.jpa.show-sql=false
+#spring.jpa.hibernate.ddl-auto=update
 
 #To use mySQL, comment out the above lines and uncomment these
 #spring.datasource.url= jdbc:mysql://localhost/local_encryption
@@ -15,6 +9,8 @@ spring.jpa.hibernate.ddl-auto=update
 #spring.datasource.password=[Replace with mySQL password]
 #spring.datasource.driverClassName=com.mysql.jdbc.Driver
 #spring.jpa.hibernate.ddl-auto=update
+#spring.datasource.url=[Replace with mySQL url]
+
 
 #Port service will listen on (generally 80 or 8080 for http and 443 for https/ssl)
 #Note that only a service listening for an https connection on port 443 can be registered for use with PureCloud


### PR DESCRIPTION
Removing support for h2 database due to snyk vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMH2DATABASE-31685.