### PR TITLE
Update Tomcat and Spring Framework versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,12 @@
         <org.aspectj.version>1.9.25.0</org.aspectj.version>
         <ch.qos.logback.version>1.5.21</ch.qos.logback.version>
         <com.fasterxml.jackson.version>2.19.4</com.fasterxml.jackson.version>
+        <jackson-bom.version>3.1.0</jackson-bom.version>
         <java.version>17</java.version>
         <scala.version>2.10.4</scala.version>
         <log4j.version>2.24.3</log4j.version>
-        <tomcat.version>10.1.49</tomcat.version>
+        <tomcat.version>10.1.52</tomcat.version>
+        <spring-framework.version>7.0.6</spring-framework.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
     </properties>
 


### PR DESCRIPTION
**Problem Description:** Snyk flagged vulnerable Tomcat, Jackson, and Spring Web MVC dependencies in the service.

```
Introduced through
org.apache.tomcat.embed:tomcat-embed-core@10.1.49
Fixed in
org.apache.tomcat.embed:tomcat-embed-core@9.0.114, @10.1.52, @11.0.18
Introduced through
tools.jackson.core:jackson-core@3.0.4
Fixed in
tools.jackson.core:jackson-core@3.1.0 
Introduced through
org.springframework.boot:spring-boot-starter-webmvc@4.0.2
Fixed in
org.springframework:spring-webmvc@6.2.17, @7.0.6
```

**Solution:** Kept Spring Boot at 4.0.2 and overrode Tomcat, Jackson, and Spring Framework to fixed versions.

**Dev Testing:** Verified with mvn dependency:tree that resolved versions are the patched ones.

**Risk Analysis:** Low risk; dependency-only version bumps with no code changes.