### PR TITLE
[RECINF-1170] Snyk Vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <org.aspectj.version>1.9.25.0</org.aspectj.version>
-        <ch.qos.logback.version>1.5.21</ch.qos.logback.version>
+        <logback.version>1.5.36</logback.version>
         <java.version>17</java.version>
         <scala.version>2.10.4</scala.version>
         <log4j.version>2.24.3</log4j.version>


### PR DESCRIPTION
Address Snyk vulnerabilities introduced by 
org.springframework:spring-web@7.0.7
org.springframework.boot:spring-boot-starter-webmvc@4.0.6
tools.jackson.core:jackson-databind@3.1.2
ch.qos.logback:logback-core@1.5.32
org.springframework.boot:spring-boot-starter-data-jpa@4.0.6

Updated spring-boot-starter-parent to version 4.0.7
Replaced ch.qos.logback.version with logback.version as that is the actual version referenced in the parent pom spring-boot-dependencies-4.0.6.pom. Also updated version to 1.5.36