### PR TITLE
[RECINF-1267] Bump Jackson-Core for Snyk FIx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <log4j.version>2.24.3</log4j.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <tomcat.version>11.0.23</tomcat.version>
+        <jackson-bom.version>3.1.5</jackson-bom.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Problem Description: 

Upgrade tools.jackson.core:jackson-databind@3.1.4 to tools.jackson.core:jackson-databind@3.1.5 to fix
  ✗ Incorrect Authorization (new) [High Severity][[https://security.snyk.io/vuln/SNYK-JAVA-TOOLSJACKSONCORE-17972609]](https://security.snyk.io/vuln/SNYK-JAVA-TOOLSJACKSONCORE-17972609%5D) in tools.jackson.core:jackson-databind@3.1.4
    introduced by tools.jackson.core:jackson-databind@3.1.4
https://www.cve.org/CVERecord?id=CVE-2026-59889

Solution: Pinned jackson-bom.versiondefiined in spring-boot-dependencies-4.0.7.pom to version 3.1.5

Dev Testing: Snyk test returns no more HIGH snyk vulnerabilities.

Risk Analysis: -